### PR TITLE
Update content.js

### DIFF
--- a/content.js
+++ b/content.js
@@ -972,13 +972,13 @@ class TextAid {
     }
     if (!suggestion) return;
 
-    this.suggestionText = suggestion;
-    this.suggestionTarget = targetEl;
     this.showSuggestion(suggestion, targetEl);
   }
 
   showSuggestion(text, targetEl) {
     this.hideSuggestion();
+    this.suggestionText = text;
+    this.suggestionTarget = targetEl;
     if (targetEl.isContentEditable) {
       this._showContentEditableGhost(text, targetEl);
     } else {


### PR DESCRIPTION
This pull request makes a minor adjustment to the way suggestion state is managed in the `TextAid` class. The assignment of `suggestionText` and `suggestionTarget` has been moved from the `onSuggestion` method to the `showSuggestion` method to ensure these properties are only set when a suggestion is actually shown.

- Refactored state management so that `suggestionText` and `suggestionTarget` are now set in `showSuggestion` instead of `onSuggestion` in `content.js` (`TextAid` class).